### PR TITLE
Fix multer dependency version

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {"start": "node server.js"},
   "dependencies": {
     "express": "^4.18.2",
-    "multer": "^1.4.5",
+    "multer": "^1.4.5-lts.1",
     "sharp": "^0.33.1",
     "simple-git": "^3.21.0"
   }


### PR DESCRIPTION
## Summary
- update multer package version in backend/package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4f3fe9c83309db9b82c508f9b45