### PR TITLE
Add placeholder constant and document usage

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,3 +19,7 @@ Open [http://localhost:3000](http://localhost:3000) to upload new images.
 Make sure this repo has write access and you are on the `main` branch with a clean working tree before running the service.
 
 The `messier.html` file must include a `<!-- MESSIER_ITEMS -->` comment inside the Messier grid. New entries will be inserted immediately before this placeholder every time you upload a photo.
+
+This comment marks where the next thumbnail will be added. The uploader replaces
+the `<!-- MESSIER_ITEMS -->` token with the new grid item and reinserts the
+placeholder so subsequent uploads keep working.

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const sharp = require('sharp');
 const simpleGit = require('simple-git');
 
+// Placeholder used to mark insertion point in messier.html
+const PLACEHOLDER = '<!-- MESSIER_ITEMS -->';
+
 // Ensure required directories exist
 fs.mkdirSync('uploads', { recursive: true });
 fs.mkdirSync(path.join(__dirname, '..', 'photos', 'messier', 'thumbs'), { recursive: true });
@@ -35,7 +38,7 @@ app.post('/upload', upload.single('image'), async (req, res) => {
     const htmlPath = path.join(__dirname, '..', 'messier.html');
     let html = fs.readFileSync(htmlPath, 'utf8');
     const entry = `<div class="grid-item photographed" onclick="openModal('${label}')" data-full="/photos/messier/${fileName}" style="background-image: url('/photos/messier/thumbs/${fileName}'); background-size: ${backgroundSize}; background-position: ${backgroundPosition};"></div>`;
-    html = html.replace('<!-- MESSIER_ITEMS -->', entry + '\n          <!-- MESSIER_ITEMS -->');
+    html = html.replace(PLACEHOLDER, entry + '\n          ' + PLACEHOLDER);
     fs.writeFileSync(htmlPath, html);
 
     await git.add(['photos/messier/' + fileName, 'photos/messier/thumbs/' + fileName, 'messier.html']);


### PR DESCRIPTION
## Summary
- add constant placeholder in `server.js`
- update README with extra info about the placeholder

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840e4f51f248330a38f8c1b87321388